### PR TITLE
Flutter 1.12 compatibility

### DIFF
--- a/lib/media_player.dart
+++ b/lib/media_player.dart
@@ -523,7 +523,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
           _controller.play();
         }
         break;
-      case AppLifecycleState.suspending:
+      case AppLifecycleState.detached:
         _controller.dispose();
         break;
       default:


### PR DESCRIPTION
Since the AppLifecycleState.suspending was changed to AppLifecycleState.detached, we need to change that to make the plugin compatible.